### PR TITLE
Reduced pool connections. Single pool instance.

### DIFF
--- a/src/infrastructure/database-queries.js
+++ b/src/infrastructure/database-queries.js
@@ -235,11 +235,7 @@ const deleteActivityLog = async ({ pk }) => {
       logError(err, "Delete activity - database query error");
       return true;
     } finally {
-      try {
-        client.release();
-      } catch (error) {
-        logError(error, "client release");
-      }
+      client.release();
     }
   } catch (err) {
     logError(err, "Delete activity - database connection error");

--- a/src/infrastructure/db-clientpool.js
+++ b/src/infrastructure/db-clientpool.js
@@ -4,9 +4,11 @@ const { Pool } = require("pg");
 
 config = {
   connectionString: process.env.DB_CONNECTION_STRING,
-  max: 20,
+  max: 5,
   connectionTimeoutMillis: 5000,
   idleTimeoutMillis: 30000,
 };
 
-module.exports = new Pool(config);
+const pool = new Pool(config);
+
+module.exports = pool;


### PR DESCRIPTION
Lot of connections were showing up in aws. As part of reducing connections,

- Reduced the activity logger client pool from 20 to 5
- Shared a single instance of pool across all imports