### PR TITLE
Limit queries as the number of logs increases

### DIFF
--- a/src/infrastructure/database-queries.js
+++ b/src/infrastructure/database-queries.js
@@ -108,7 +108,7 @@ const retrieveActivityTable = async () => {
           WHERE
             a.status = 'current'
           ORDER BY
-            epoch_ms DESC;`,
+            epoch_ms DESC LIMIT 30;`,
   };
   try {
     const client = await pool.connect();


### PR DESCRIPTION
Temporary fix. Permanent solution is a filter on the logs